### PR TITLE
chore(core): keep library setups associated with Application

### DIFF
--- a/engine/classes/Elgg/Includer.php
+++ b/engine/classes/Elgg/Includer.php
@@ -9,12 +9,6 @@ namespace Elgg;
 final class Includer {
 
 	/**
-	 * @var array
-	 * @internal
-	 */
-	static $_setups;
-
-	/**
 	 * Include a file with as little context as possible
 	 *
 	 * @param string $file File to include
@@ -41,10 +35,6 @@ final class Includer {
 	 * @return mixed
 	 */
 	static public function requireFileOnce($file) {
-		$result = require_once $file;
-		if ($result instanceof \Closure) {
-			self::$_setups[] = $result;
-		}
-		return $result;
+		return require_once $file;
 	}
 }

--- a/engine/classes/ElggPlugin.php
+++ b/engine/classes/ElggPlugin.php
@@ -1,6 +1,7 @@
 <?php
 
 use Elgg\Includer;
+use Elgg\Application;
 
 /**
  * Stores site-side plugin settings as private data.
@@ -851,7 +852,7 @@ class ElggPlugin extends \ElggObject {
 			
 			$autoload_file = 'vendor/autoload.php';
 			if ($this->canReadFile($autoload_file)) {
-				Includer::requireFileOnce("{$this->path}/{$autoload_file}");
+				Application::requireSetupFileOnce("{$this->path}/{$autoload_file}");
 			}
 		}
 
@@ -865,9 +866,9 @@ class ElggPlugin extends \ElggObject {
 		// include start file if it exists
 		if ($flags & ELGG_PLUGIN_INCLUDE_START) {
 			if ($this->canReadFile('start.php')) {
-				$result = Includer::requireFileOnce("{$this->path}/start.php");
+				$result = Application::requireSetupFileOnce("{$this->path}/start.php");
 				if ($result instanceof \Closure) {
-					$result(_elgg_services()->hooks->getEvents(), _elgg_services()->hooks);
+					$result();
 				}
 			}
 			


### PR DESCRIPTION
Don't pass internal API objects to plugin `start.php` files.